### PR TITLE
Export B64enc and B64dec

### DIFF
--- a/jose_test.go
+++ b/jose_test.go
@@ -18,8 +18,8 @@ func TestB64Enc(t *testing.T) {
 	fmt.Println("--> TestB64Enc")
 	in := []byte{0x00, 0xff}
 	out := "AP8"
-	if x := b64enc(in); x != out {
-		t.Errorf("b64enc(%v) = %v, want %v", in, x, out)
+	if x := B64enc(in); x != out {
+		t.Errorf("B64enc(%v) = %v, want %v", in, x, out)
 	}
 }
 
@@ -27,9 +27,9 @@ func TestB64Dec(t *testing.T) {
 	fmt.Println("--> TestB64Dec")
 	in := "_wA"
 	out := []byte{0xFF, 0x00}
-	x, err := b64dec(in)
+	x, err := B64dec(in)
 	if (err != nil) || (bytes.Compare(x, out) != 0) {
-		t.Errorf("b64dec(%v) = %v, want %v", in, x, out)
+		t.Errorf("B64dec(%v) = %v, want %v", in, x, out)
 	}
 }
 
@@ -239,7 +239,7 @@ func TestEcJwsVerify(t *testing.T) {
 }
 
 func bigIntFromB64(b64 string) *big.Int {
-	bytes, _ := b64dec(b64)
+	bytes, _ := B64dec(b64)
 	x := big.NewInt(0)
 	x.SetBytes(bytes)
 	return x
@@ -263,7 +263,7 @@ func TestRsaJwsSign(t *testing.T) {
 		rsa.PrecomputedValues{},
 	}
 
-	payload, _ := b64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
+	payload, _ := B64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
 
 	jws, err := Sign(RSAPKCS1WithSHA256, priv, payload)
 	if err != nil {
@@ -292,7 +292,7 @@ func TestRsaPssJwsSign(t *testing.T) {
 		rsa.PrecomputedValues{},
 	}
 
-	payload, _ := b64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
+	payload, _ := B64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
 
 	jws, err := Sign(RSAPSSWithSHA256, priv, payload)
 	if err != nil {
@@ -315,7 +315,7 @@ func TestEcJwsSign(t *testing.T) {
 
 	priv := ecdsa.PrivateKey{ecdsa.PublicKey{elliptic.P521(), x, y}, d}
 
-	payload, _ := b64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
+	payload, _ := B64dec("It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.")
 
 	jws, err := Sign(ECDSAWithSHA512, priv, payload)
 	if err != nil {

--- a/jwk.go
+++ b/jwk.go
@@ -67,7 +67,7 @@ func (jwk *JsonWebKey) UnmarshalJSON(data []byte) error {
 			N: raw.N.ToBigInt(),
 			E: raw.E.ToInt(),
 		}
-		jwk.Thumbprint = b64enc(raw.N)
+		jwk.Thumbprint = B64enc(raw.N)
 	case "EC":
 		curve, err := name2curve(raw.Crv)
 		if err != nil {
@@ -79,7 +79,7 @@ func (jwk *JsonWebKey) UnmarshalJSON(data []byte) error {
 			X:     raw.X.ToBigInt(),
 			Y:     raw.Y.ToBigInt(),
 		}
-		jwk.Thumbprint = b64enc(raw.X) + b64enc(raw.Y)
+		jwk.Thumbprint = B64enc(raw.X) + B64enc(raw.Y)
 	}
 
 	return nil

--- a/jws.go
+++ b/jws.go
@@ -76,7 +76,7 @@ func (jws JsonWebSignature) MarshalCompact() ([]byte, error) {
 		return []byte{}, errors.New("Cannot marshal unsigned JWS")
 	}
 
-	return []byte(b64enc(jws.Protected) + "." + b64enc(jws.Payload) + "." + b64enc(jws.Signature)), nil
+	return []byte(B64enc(jws.Protected) + "." + B64enc(jws.Payload) + "." + B64enc(jws.Signature)), nil
 }
 
 func UnmarshalCompact(data []byte) (JsonWebSignature, error) {
@@ -88,15 +88,15 @@ func UnmarshalCompact(data []byte) (JsonWebSignature, error) {
 
 	// Decode simple fields
 	var err error
-	jws.Protected, err = b64dec(parts[0])
+	jws.Protected, err = B64dec(parts[0])
 	if err != nil {
 		return jws, err
 	}
-	jws.Payload, err = b64dec(parts[1])
+	jws.Payload, err = B64dec(parts[1])
 	if err != nil {
 		return jws, err
 	}
-	jws.Signature, err = b64dec(parts[2])
+	jws.Signature, err = B64dec(parts[2])
 	if err != nil {
 		return jws, err
 	}
@@ -112,7 +112,7 @@ func UnmarshalCompact(data []byte) (JsonWebSignature, error) {
 }
 
 func prepareInput(jws JsonWebSignature) (crypto.Hash, []byte, error) {
-	input := []byte(b64enc(jws.Protected) + "." + b64enc(jws.Payload))
+	input := []byte(B64enc(jws.Protected) + "." + B64enc(jws.Payload))
 	zeroh := crypto.Hash(0)
 	zerob := []byte{}
 

--- a/util.go
+++ b/util.go
@@ -25,11 +25,11 @@ func unpad(x string) string {
 	return strings.Replace(x, "=", "", -1)
 }
 
-func b64enc(x []byte) string {
+func B64enc(x []byte) string {
 	return unpad(base64.URLEncoding.EncodeToString(x))
 }
 
-func b64dec(x string) ([]byte, error) {
+func B64dec(x string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(pad(x))
 }
 
@@ -37,7 +37,7 @@ func b64dec(x string) ([]byte, error) {
 type JsonBuffer json.RawMessage
 
 func (jb JsonBuffer) MarshalJSON() ([]byte, error) {
-	str := b64enc(jb)
+	str := B64enc(jb)
 	return json.Marshal(str)
 }
 
@@ -48,7 +48,7 @@ func (jb *JsonBuffer) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	*jb, err = b64dec(str)
+	*jb, err = B64dec(str)
 	return err
 }
 
@@ -65,7 +65,7 @@ func (jb JsonBuffer) ToInt() int {
 // Utils
 
 func bigint2base64(x *big.Int) string {
-	return b64enc(x.Bytes())
+	return B64enc(x.Bytes())
 }
 
 func int2base64(x int) string {
@@ -74,7 +74,7 @@ func int2base64(x int) string {
 }
 
 func base642bigint(x string) (*big.Int, error) {
-	data, err := b64dec(x)
+	data, err := B64dec(x)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This would allow https://github.com/letsencrypt/boulder to remove duplicate code from `util.go`
